### PR TITLE
Use the correct style for short names of CC licenses

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 ## Contributing
 
-All copyrightable contributions to the Open Decision Framework are accepted under the [Creative Commons CC-BY-SA 4.0](http://creativecommons.org/licenses/by-sa/4.0/) license. 
+All copyrightable contributions to the Open Decision Framework are accepted under the [Creative Commons CC BY-SA 4.0](http://creativecommons.org/licenses/by-sa/4.0/) license. 
 
 Please open issues and submit pull requests to discuss and suggest alterations to the Open Decision Framework or maturity model.
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,1 +1,1 @@
-Creative Commons Attribution ShareAlike 4.0 International ([CC-BY-SA 4.0] (http://creativecommons.org/licenses/by-sa/4.0/))
+Creative Commons Attribution ShareAlike 4.0 International ([CC BY-SA 4.0] (http://creativecommons.org/licenses/by-sa/4.0/))

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ For the past few years at Red Hat, we’ve been grappling with the challenges of
 The Open Decision Framework contains the collective wisdom of Red Hatters, compiled into a flexible framework that helps decision makers and leaders seek out diverse perspectives and collaborate across teams and geos, to make better decisions. 
 
 ## Licensing
-The Open Decision Framework is available under a [Creative Commons CC-BY-SA 4.0 license](http://creativecommons.org/licenses/by-sa/4.0/). The content reflects the internal version we use at Red Hat, minus a few links to content on our intranet or other internal websites. 
+The Open Decision Framework is available under a [Creative Commons CC BY-SA 4.0 license](http://creativecommons.org/licenses/by-sa/4.0/). The content reflects the internal version we use at Red Hat, minus a few links to content on our intranet or other internal websites. 
 
 ### Contributing
 
-All copyrightable contributions to the Open Decision Framework are accepted under the [Creative Commons CC-BY-SA 4.0 license](http://creativecommons.org/licenses/by-sa/4.0/). 
+All copyrightable contributions to the Open Decision Framework are accepted under the [Creative Commons CC BY-SA 4.0 license](http://creativecommons.org/licenses/by-sa/4.0/). 
 * [Learn more](CONTRIBUTING.md)
 
 ### Modifying and forking


### PR DESCRIPTION
It's a tiny fix, but a fix nonetheless